### PR TITLE
fix HunyuanOCR crash in vLLM

### DIFF
--- a/Hunyuan-OCR-master/Hunyuan-OCR-vllm/run_hy_ocr.py
+++ b/Hunyuan-OCR-master/Hunyuan-OCR-vllm/run_hy_ocr.py
@@ -3,6 +3,7 @@ import base64
 from openai import OpenAI
 from tqdm import tqdm
 from typing import Dict, List
+import mimetypes
 
 def encode_image(image_path: str) -> str:
     """
@@ -28,6 +29,11 @@ def create_chat_messages(image_path: str, prompt: str) -> List[Dict]:
     Returns:
         List of message dictionaries
     """
+    # Detect MIME type (jpg/png/webp/etc)
+    mime, _ = mimetypes.guess_type(image_path)
+    if mime is None:
+        mime = "image/jpeg"  # fallback
+
     return [
         {"role": "system", "content": ""},
         {
@@ -35,9 +41,7 @@ def create_chat_messages(image_path: str, prompt: str) -> List[Dict]:
             "content": [
                 {
                     "type": "image_url",
-                    "image_url": {
-                        "url": f"data:image/jpeg;base64,{encode_image(image_path)}"
-                    }
+                    "image_url": f"data:{mime};base64,{encode_image(image_path)}"
                 },
                 {"type": "text", "text": prompt}
             ]


### PR DESCRIPTION
This PR fixes a runtime error in the vLLM multimodal pipeline when running HunyuanOCR.
The issue #35  was caused by sending images using the wrong message schema, which led vLLM to misinterpret the image input and generate an invalid tensor shape. 
```css
ValueError: image_grid_thw has rank 3 but expected 2.
Expected shape: ('ni', 3), but got torch.Size([2, 1, 3])
```
## what i changed

1. updated request format
```css
{ "type": "image_url", "image_url": { "url": "data:image/jpeg;base64,..." } }
```
to 
```css
{
    "type": "image_url",
    "image_url": f"data:{mime};base64,{encode_image(image_path)}"
 },
```
2. Added automatic MIME-type detection to ensure images are sent with the correct format (png/jpeg/webp/etc)
3. Ensured image_url is a string, not a nested object, which aligns with vLLM’s expected schema for HuggingFace vision models.