### PR TITLE
Fix Base SFT training for transformers 5.15

### DIFF
--- a/docs/data_format.md
+++ b/docs/data_format.md
@@ -76,31 +76,26 @@ PACK_OUTPUT=./data/parsing_packed_20480.jsonl \
 
 ### Output schema (packed JSONL)
 
-Each output line contains:
+Each output line is a JSON array. Each item is the sample consumed by the training dataset:
 
 ```json
-{
-    "packed_samples": [
-        {
-            "image_path": ["/abs/path/1.png"],
-            "conversations": [...]
-        },
-        {
-            "image_path": ["/abs/path/2.png"],
-            "conversations": [...]
-        },
-        ...
-    ],
-    "cu_seqlens": [0, 4123, 8567, ..., 20351],
-    "total_tokens": 20351
-}
+[
+    {
+        "image": "/abs/path/1.png",
+        "question": "Extract the text from the image",
+        "answer": "Recognized document text",
+        "num_tokens": 4123
+    },
+    {
+        "image": "/abs/path/2.png",
+        "question": "Extract the text from the image",
+        "answer": "Recognized document text",
+        "num_tokens": 4444
+    }
+]
 ```
 
-**Fields:**
-
-- `packed_samples`: original raw samples concatenated in this pack
-- `cu_seqlens`: cumulative token boundaries (for FlashAttention varlen)
-- `total_tokens`: sum ≤ `pack_length`
+The sum of `num_tokens` in one array is at most `pack_length`. `cu_seqlens` is recomputed by the training collator and is not stored in the JSONL.
 
 ### Performance tips
 
@@ -117,9 +112,9 @@ python -c "
 import json
 with open('./data/parsing_packed_20480.jsonl') as f:
     for i, line in enumerate(f):
-        r = json.loads(line)
-        print(f'pack {i}: {len(r[\"packed_samples\"])} samples, '
-              f'{r[\"total_tokens\"]} tokens')
+        pack = json.loads(line)
+        print(f'pack {i}: {len(pack)} samples, '
+              f'{sum(item.get(\"num_tokens\", 0) for item in pack)} tokens')
         if i >= 3: break
 "
 ```

--- a/docs/data_format.md
+++ b/docs/data_format.md
@@ -12,7 +12,26 @@ The pipeline: raw JSONL → tokenize + count → pack → training-ready JSONL.
 
 ## 1. Raw OCR JSONL Schema
 
-Each line in a raw JSONL file is one training sample:
+Each line in a raw JSONL file is one training sample. The packing script's `normalize_sample()`
+accepts two input formats, resolved in the following priority order.
+
+### Format A (preferred): `conv` + `img_path_sh` / `img_path_cq`
+
+```json
+{
+  "img_path_sh": "/absolute/path/to/image.png",
+  "conv": [
+    { "question": "Extract all body text from the document image as markdown...", "answer": "# Title\n\nBody text ..." }
+  ]
+}
+```
+
+| Field                       | Type         | Required | Notes                                                                      |
+| --------------------------- | ------------ | -------- | -------------------------------------------------------------------------- |
+| `img_path_sh`/`img_path_cq` | `str`        | ✅       | Absolute image path; `img_path_sh` is used if present, else `img_path_cq`. |
+| `conv`                      | `list[dict]` | ✅       | The 0-th turn's `question` / `answer` is used.                             |
+
+### Format B (fallback): `image_path` + `conversations`
 
 ```json
 {
@@ -20,19 +39,20 @@ Each line in a raw JSONL file is one training sample:
   "conversations": [
     {
       "from": "human",
-      "value": "<image>\n提取文档图片中正文的所有信息用markdown格式表示..."
+      "value": "<image>\nExtract all body text from the document image as markdown..."
     },
     { "from": "gpt", "value": "# Title\n\nBody text ..." }
   ]
 }
 ```
 
-**Fields:**
+| Field           | Type         | Required | Notes                                                                                |
+| --------------- | ------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image_path`    | `list[str]`  | ✅       | List of absolute paths; the first image is used.                |
+| `conversations` | `list[dict]` | ✅       | Alternating `human`/`gpt` (or `user`/`assistant`) turns. The `<image>` placeholder in the `human` value is stripped and the remainder becomes the question. |
 
-| Field           | Type         | Required | Notes                                                                                                      |
-| --------------- | ------------ | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `image_path`    | `list[str]`  | ✅       | Absolute paths. Usually 1 image; multi-image supported.                                                    |
-| `conversations` | `list[dict]` | ✅       | Alternating `human` / `gpt` turns. `<image>` placeholder in `human` value indicates image insertion point. |
+> Format B is only used when the sample has no `conv` field. Both formats are normalized to an
+> `image` / `question` / `answer` triple.
 
 ## 2. Packing Pipeline
 

--- a/docs/data_format_zh.md
+++ b/docs/data_format_zh.md
@@ -76,31 +76,26 @@ PACK_OUTPUT=./data/parsing_packed_20480.jsonl \
 
 ### 输出格式（打包后的 JSONL）
 
-每一行输出格式如下：
+每一行是一个 JSON 数组，数组中的每项是训练 dataset 实际消费的样本：
 
 ```json
-{
-    "packed_samples": [
-        {
-            "image_path": ["/abs/path/1.png"],
-            "conversations": [...]
-        },
-        {
-            "image_path": ["/abs/path/2.png"],
-            "conversations": [...]
-        },
-        ...
-    ],
-    "cu_seqlens": [0, 4123, 8567, ..., 20351],
-    "total_tokens": 20351
-}
+[
+    {
+        "image": "/abs/path/1.png",
+        "question": "提取图片中的文字",
+        "answer": "识别出的正文",
+        "num_tokens": 4123
+    },
+    {
+        "image": "/abs/path/2.png",
+        "question": "提取图片中的文字",
+        "answer": "识别出的正文",
+        "num_tokens": 4444
+    }
+]
 ```
 
-**字段：**
-
-- `packed_samples`：本 pack 内拼接的原始样本
-- `cu_seqlens`：累计 token 边界（供 FlashAttention varlen 使用）
-- `total_tokens`：合计 ≤ `pack_length`
+数组内样本的 `num_tokens` 总和不超过 `pack_length`。`cu_seqlens` 由训练 collator 根据实际处理后的序列重新计算，不写入 JSONL。
 
 ### 性能提示
 
@@ -117,9 +112,9 @@ python -c "
 import json
 with open('./data/parsing_packed_20480.jsonl') as f:
     for i, line in enumerate(f):
-        r = json.loads(line)
-        print(f'pack {i}: {len(r[\"packed_samples\"])} samples, '
-              f'{r[\"total_tokens\"]} tokens')
+        pack = json.loads(line)
+        print(f'pack {i}: {len(pack)} samples, '
+              f'{sum(item.get(\"num_tokens\", 0) for item in pack)} tokens')
         if i >= 3: break
 "
 ```

--- a/docs/data_format_zh.md
+++ b/docs/data_format_zh.md
@@ -12,7 +12,25 @@
 
 ## 1. 原始 OCR JSONL 格式
 
-原始 JSONL 每行是一条训练样本：
+原始 JSONL 每行是一条训练样本。打包脚本 `normalize_sample()` 同时支持两种输入格式，并按下述优先级解析。
+
+### 格式 A（优先）：`conv` + `img_path_sh` / `img_path_cq`
+
+```json
+{
+  "img_path_sh": "/absolute/path/to/image.png",
+  "conv": [
+    { "question": "提取文档图片中正文的所有信息用markdown格式表示...", "answer": "# Title\n\nBody text ..." }
+  ]
+}
+```
+
+| 字段                | 类型         | 是否必填 | 说明|
+| --------------------------- | ------------ | :------: | ----------------------------------------------------------------- |
+| `img_path_sh`/`img_path_cq` | `str`        |    ✅    | 图片绝对路径，优先取 `img_path_sh`，否则取 `img_path_cq`。        |
+| `conv`                | `list[dict]` |    ✅    | 取第 0 项的 `question` / `answer`。                               |
+
+### 格式 B（兼容）：`image_path` + `conversations`
 
 ```json
 {
@@ -27,12 +45,12 @@
 }
 ```
 
-**字段说明：**
-
-| 字段            | 类型         | 是否必填 | 说明                                                                                            |
+| 字段            | 类型         | 是否必填 | 说明|
 | --------------- | ------------ | :------: | ----------------------------------------------------------------------------------------------- |
-| `image_path`    | `list[str]`  |    ✅    | 绝对路径。通常 1 张图，也支持多图。                                                             |
-| `conversations` | `list[dict]` |    ✅    | `human` / `gpt` 交替对话。`human` 值中的 `<image>` 占位符表示图片插入点。                       |
+| `image_path`    | `list[str]`  |    ✅    | 绝对路径列表，取第 0 张。|
+| `conversations` | `list[dict]` |    ✅    | `human`/`gpt`（或 `user`/`assistant`）交替对话；`human` 值中的 `<image>` 占位符会被去除后作为 question。 |
+
+> 只有当样本不含 `conv` 字段时才回退到格式 B。两种格式最终都会被规范化为 `image` / `question` / `answer`三元组。
 
 ## 2. 打包流水线
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ tokenizers>=0.20.0
 Pillow>=10.0.0
 opencv-python>=4.8.0
 numpy>=1.24.0
+lmdb>=1.4.0
+binpacking>=1.5.2
 
 # Distributed / performance
 einops>=0.7.0

--- a/scripts/sft_base.sh
+++ b/scripts/sft_base.sh
@@ -12,7 +12,7 @@
 # Multi-node: pass NNODES / NODE_RANK / MASTER_ADDR / MASTER_PORT as env vars.
 # ============================================================================
 
-set -e
+set -euo pipefail
 
 # Activate your Python environment before running:
 #   source /path/to/miniconda3/bin/activate && conda activate hyocr
@@ -43,6 +43,11 @@ batch_size=${BATCH_SIZE:-1}
 grad_accum_steps=${GRAD_ACCUM:-1}
 num_epochs=${EPOCHS:-5}
 save_steps=${SAVE_STEPS:-200}
+data_flatten=${DATA_FLATTEN:-True}
+data_packing=${DATA_PACKING:-True}
+packed_max_length=${PACKED_MAX_LENGTH:-20480}
+dataloader_workers=${DATALOADER_WORKERS:-4}
+max_steps=${MAX_STEPS:--1}
 
 entry_file=train/train_hunyuan.py
 
@@ -64,37 +69,39 @@ echo "  grad_accum    : ${grad_accum_steps}"
 echo "========================================"
 
 # ────────────── Training args ──────────────
-args="
-    --model_name_or_path ${model_name_or_path} \
-    --train_data_path ${train_data_path} \
-    --image_folder ${image_path} \
-    --data_flatten True \
-    --data_packing True \
-    --tune_mm_vision True \
-    --tune_mm_mlp True \
-    --tune_mm_llm True \
-    --bf16 \
-    --output_dir ${output_dir} \
-    --num_train_epochs ${num_epochs} \
-    --per_device_train_batch_size ${batch_size} \
-    --per_device_eval_batch_size $((batch_size*2)) \
-    --gradient_accumulation_steps ${grad_accum_steps} \
-    --eval_strategy no \
-    --save_strategy steps \
-    --save_steps ${save_steps} \
-    --save_total_limit 3 \
-    --learning_rate ${lr} \
-    --weight_decay 0.01 \
-    --warmup_ratio 0.03 \
-    --max_grad_norm 1 \
-    --lr_scheduler_type cosine_with_min_lr \
-    --logging_steps 1 \
-    --packed_max_length 20480 \
-    --gradient_checkpointing True \
-    --dataloader_num_workers 4 \
-    --run_name ${run_name} \
-    --logging_dir ${TENSORBOARD_DIR} \
-    --report_to tensorboard"
+args=(
+    --model_name_or_path "$model_name_or_path"
+    --train_data_path "$train_data_path"
+    --image_folder "$image_path"
+    --data_flatten "$data_flatten"
+    --data_packing "$data_packing"
+    --tune_mm_vision True
+    --tune_mm_mlp True
+    --tune_mm_llm True
+    --bf16
+    --output_dir "$output_dir"
+    --num_train_epochs "$num_epochs"
+    --max_steps "$max_steps"
+    --per_device_train_batch_size "$batch_size"
+    --per_device_eval_batch_size "$((batch_size * 2))"
+    --gradient_accumulation_steps "$grad_accum_steps"
+    --eval_strategy no
+    --save_strategy steps
+    --save_steps "$save_steps"
+    --save_total_limit 3
+    --learning_rate "$lr"
+    --weight_decay 0.01
+    --warmup_ratio 0.03
+    --max_grad_norm 1
+    --lr_scheduler_type cosine_with_min_lr
+    --logging_steps 1
+    --packed_max_length "$packed_max_length"
+    --gradient_checkpointing True
+    --dataloader_num_workers "$dataloader_workers"
+    --run_name "$run_name"
+    --logging_dir "$TENSORBOARD_DIR"
+    --report_to tensorboard
+)
 
 # ────────────── Launch ──────────────
 echo "Launch training on NODE_RANK=${NODE_RANK}"
@@ -103,4 +110,4 @@ torchrun --nproc_per_node="${NPROC_PER_NODE}" \
          --master_port="${MASTER_PORT}" \
          --node_rank="${NODE_RANK}" \
          --nnodes="${NNODES}" \
-         ${entry_file} "${args}" 2>&1 | tee "${output_dir}/train_${NODE_RANK}.log"
+         "${entry_file}" "${args[@]}" 2>&1 | tee "${output_dir}/train_${NODE_RANK}.log"

--- a/tools/pipeline_count_and_pack.py
+++ b/tools/pipeline_count_and_pack.py
@@ -55,6 +55,37 @@ class DataArguments:
 
 
 # ---------------------------------------------------------------------------
+# Input schema normalization
+# ---------------------------------------------------------------------------
+def normalize_sample(data: dict) -> tuple[str, str, str] | None:
+    """Convert supported raw OCR schemas to image/question/answer fields."""
+    if data.get("conv"):
+        turn = data["conv"][0]
+        image_path = data.get("img_path_sh") or data.get("img_path_cq")
+        question = turn.get("question", "")
+        answer = turn.get("answer", "")
+    else:
+        image_paths = data.get("image_path") or []
+        conversations = data.get("conversations") or []
+        image_path = image_paths[0] if image_paths else None
+        question = ""
+        answer = ""
+        for turn in conversations:
+            role = turn.get("from") or turn.get("role")
+            value = turn.get("value", turn.get("content", ""))
+            if isinstance(value, list):
+                value = " ".join(str(part.get("text", "")) for part in value if isinstance(part, dict))
+            if role in ("human", "user") and not question:
+                question = str(value).replace("<image>", "").strip()
+            elif role in ("gpt", "assistant") and not answer:
+                answer = str(value)
+
+    if not image_path or not question or not answer:
+        return None
+    return str(image_path), question, answer
+
+
+# ---------------------------------------------------------------------------
 # Token calculation
 # ---------------------------------------------------------------------------
 def calculate_tokens(image_path: str, question: str, answer: str, system_prompt: str, hunyuan_processor) -> int:
@@ -159,19 +190,10 @@ def count_tokens_for_file(
             try:
                 data = json.loads(line_str)
 
-                # Extract question/answer from conv
-                if not data.get("conv") or len(data["conv"]) == 0:
+                sample = normalize_sample(data)
+                if sample is None:
                     return None
-                conv = data["conv"][0]
-                question = conv.get("question", "")
-                answer = conv.get("answer", "")
-                if not question or not answer:
-                    return None
-
-                # Extract image path
-                img_path = data.get("img_path_sh") or data.get("img_path_cq")
-                if not img_path:
-                    return None
+                img_path, question, answer = sample
 
                 # Calculate tokens
                 num_tokens = calculate_tokens(img_path, question, answer, system_prompt, processor)

--- a/train/data_processor.py
+++ b/train/data_processor.py
@@ -9,6 +9,23 @@ import torch
 from PIL import Image
 from torch.utils.data import Dataset
 from transformers import HunYuanVLProcessor
+from transformers.models.hunyuan_vl.modeling_hunyuan_vl import HunYuanVLModel
+
+
+class _RopeIndexShim:
+    """Lightweight carrier that reuses the model's exact multimodal position-id logic.
+
+    ``HunYuanVLModel.get_rope_index`` / ``get_vision_position_ids`` depend only on
+    ``self.config`` (no weights, no submodules), so we bind them to a shim holding just
+    the config. This guarantees the packed collator's per-sample position_ids match the
+    model's own convention without instantiating the full (multi-billion parameter) model.
+    """
+
+    get_rope_index = HunYuanVLModel.get_rope_index
+    get_vision_position_ids = HunYuanVLModel.get_vision_position_ids
+
+    def __init__(self, config):
+        self.config = config
 
 
 class VLDataset(Dataset):
@@ -23,12 +40,17 @@ class VLDataset(Dataset):
         image_lmdb_root: str | None = None,
         max_length: int = 2048,
         is_packed: bool = False,
+        model_config: Any = None,
     ):
         super().__init__()
         self.processor = processor
         self.max_length = max_length
         self.image_folder = image_folder
         self.is_packed = is_packed
+        # For packed training we must emit per-sample multimodal position_ids that restart
+        # at each sample boundary. We reuse the model's own get_rope_index via a config-only
+        # shim so the layout matches the model exactly.
+        self._rope_shim = _RopeIndexShim(model_config) if (is_packed and model_config is not None) else None
 
         # Load data from one or more files (comma-separated paths supported)
         # Supports both JSON (.json) and JSONL (.jsonl) formats
@@ -196,6 +218,7 @@ class VLDataset(Dataset):
             text=[text],
             images=image,
             padding=False,
+            return_mm_token_type_ids=True,
             return_tensors="pt",
         )
 
@@ -203,10 +226,10 @@ class VLDataset(Dataset):
         input_ids = inputs["input_ids"][0]
         labels = input_ids.clone()
 
-        # Mask image tokens (ignore loss for image tokens)
-        # image_token_id = 120120  # self.processor.image_token_id
-        # image_token_mask = (input_ids == image_token_id)
-        # labels[inputs["image_mask"][0]] = -100
+        # Image placeholders and the prompt are context, not prediction targets.
+        image_token_id = getattr(self.processor, "image_token_id", None)
+        if image_token_id is not None:
+            labels[input_ids == image_token_id] = -100
 
         # Mask the prompt part (only compute loss on assistant's response)
         # Find the assistant token position
@@ -219,17 +242,38 @@ class VLDataset(Dataset):
             text=[assistant_text],
             images=image,
             padding=False,
+            return_mm_token_type_ids=True,
             return_tensors="pt",
         )
         prompt_length = assistant_inputs["input_ids"].shape[1]
         labels[:prompt_length] = -100  # Ignore loss for prompt tokens
 
+        mm_token_type_ids = inputs.get("mm_token_type_ids")
+        if mm_token_type_ids is not None and mm_token_type_ids.shape[0] == 1:
+            mm_token_type_ids = mm_token_type_ids[0]
+
+        # For packed training, precompute this sample's multimodal 3D position_ids using the
+        # model's own get_rope_index (via the config-only shim). These positions start at 0 for
+        # every sample; concatenating them in the packed collator — together with a block-diagonal
+        # causal mask — reproduces the varlen/packed attention semantics natively.
+        position_ids = None
+        if self._rope_shim is not None:
+            rope_positions, _ = self._rope_shim.get_rope_index(
+                input_ids=inputs["input_ids"],
+                mm_token_type_ids=inputs["mm_token_type_ids"],
+                image_grid_thw=inputs.get("image_grid_thw"),
+                attention_mask=inputs["attention_mask"],
+            )
+            # rope_positions: [num_mrope_axes, batch=1, seq_len] -> drop batch dim
+            position_ids = rope_positions[:, 0, :]
+
         return {
             "input_ids": input_ids,
-            "attention_mask": inputs["attention_mask"],
-            "pixel_values": inputs.get("pixel_values", None),
-            "image_grid_thw": inputs.get("image_grid_thw", None),
-            "position_ids": inputs["position_ids"],
+            "attention_mask": inputs["attention_mask"][0],
+            "pixel_values": inputs.get("pixel_values"),
+            "image_grid_thw": inputs.get("image_grid_thw"),
+            "position_ids": position_ids,
+            "mm_token_type_ids": mm_token_type_ids,
             "labels": labels,
         }
 
@@ -239,12 +283,14 @@ class PackedVLDataCollator:
     Data collator that packs multiple samples into a single sequence.
     This is more efficient than padding, especially when samples have varying lengths.
 
-    Key features:
-    - Concatenates multiple samples into one sequence
-    - Creates block-diagonal attention mask to isolate different samples
-    - Generates correct position_ids for each sample (restarting from 0)
-    - Handles image tokens correctly
-    - Supports MTP (Multi-Token Prediction) extra data packing
+    Packing is expressed entirely through inputs the native HunYuanVL forward already
+    understands — no attention monkey-patching:
+    - Concatenates the packed samples into one [1, total_len] sequence.
+    - Emits a block-diagonal additive causal mask [1, 1, L, L] so each sample only attends
+      within itself (varlen semantics).
+    - Concatenates each sample's multimodal 3D position_ids (each restarting from 0), which
+      the dataset precomputes via the model's own get_rope_index.
+    - Merges visual inputs as flat pixel_values / [num_images, 3] image_grid_thw.
     """
 
     def __init__(self, processor: HunYuanVLProcessor, packed_max_length: int = 2048):
@@ -264,30 +310,26 @@ class PackedVLDataCollator:
                 "expected a Processor with .tokenizer or a Tokenizer instance."
             )
 
-    def _create_packed_attention_mask(self, sample_lengths: list[int], device: torch.device) -> torch.Tensor:
-        """
-        Create block-diagonal attention mask for packed sequences.
-        Each sample can only attend to tokens within the same sample.
+    def _create_packed_causal_mask(self, sample_lengths: list[int], dtype: torch.dtype) -> torch.Tensor:
+        """Block-diagonal causal mask for a packed sequence.
 
-        Args:
-            sample_lengths: List of lengths for each sample in the packed sequence
-            device: Device to create the mask on
-
-        Returns:
-            Attention mask of shape [total_length, total_length]
+        Returns an additive mask of shape ``[1, 1, L, L]`` where, within each sample block,
+        a token may attend to itself and earlier tokens of the same sample, and everything
+        outside its own block is masked with ``-inf``. This is exactly the varlen/packed
+        attention pattern, expressed in the form the native HunYuanVL forward consumes.
         """
         total_length = sum(sample_lengths)
-        # Create mask with 1s (allowed) and 0s (blocked)
-        mask = torch.zeros((total_length, total_length), dtype=torch.bool, device=device)
-
+        min_val = torch.finfo(dtype).min
+        mask = torch.full((total_length, total_length), min_val, dtype=dtype)
         start_idx = 0
         for length in sample_lengths:
             end_idx = start_idx + length
-            # Allow attention within this sample
-            mask[start_idx:end_idx, start_idx:end_idx] = True
+            block = torch.triu(
+                torch.full((length, length), min_val, dtype=dtype), diagonal=1
+            )
+            mask[start_idx:end_idx, start_idx:end_idx] = block
             start_idx = end_idx
-
-        return mask
+        return mask.unsqueeze(0).unsqueeze(0)
 
     def __call__(self, features: list[Any]) -> dict[str, torch.Tensor]:
         """
@@ -304,34 +346,33 @@ class PackedVLDataCollator:
             # We expect batch_size=1 for packed data, so features[0] is the packed batch
             features = features[0]
 
-        # Now features is a list of dicts, process normally
-        # Separate different types of inputs
         all_input_ids = [f["input_ids"] for f in features]
         all_labels = [f["labels"] for f in features]
         all_position_ids = [f["position_ids"] for f in features]
 
-        # Pack sequences: original tokens first, MTP tokens appended at the end
-        packed_input_ids = []  # Original sequence tokens
-        packed_labels = []  # Original sequence labels
-        packed_position_ids = []  # Original sequence position_ids
+        packed_input_ids = []
+        packed_labels = []
+        packed_position_ids = []  # each entry is [num_mrope_axes, seq_len]
         sample_lengths = []
 
         current_length = 0
-        packed_sample_indices = []  # Track which samples were actually packed
+        packed_sample_indices = []
         for idx, (input_ids, labels, position_ids) in enumerate(zip(all_input_ids, all_labels, all_position_ids)):
+            if position_ids is None:
+                raise ValueError(
+                    "PackedVLDataCollator requires per-sample position_ids. The processor did not "
+                    "return position_ids for a sample; ensure the HunYuanVL processor emits them."
+                )
             seq_len = len(input_ids)
 
-            # Check if adding this sample would exceed max_length
             if current_length + seq_len > self.max_length:
-                # If we haven't added any samples yet, truncate this one
                 if current_length == 0:
                     packed_input_ids.append(input_ids[: self.max_length])
                     packed_labels.append(labels[: self.max_length])
-                    packed_position_ids.append(position_ids[:, :, : self.max_length])
+                    packed_position_ids.append(position_ids[:, : self.max_length])
                     sample_lengths.append(self.max_length)
                     packed_sample_indices.append(idx)
                     current_length = self.max_length
-                # Otherwise, stop packing
                 break
 
             packed_input_ids.append(input_ids)
@@ -341,13 +382,13 @@ class PackedVLDataCollator:
             packed_sample_indices.append(idx)
             current_length += seq_len
 
-        # Concatenate original sequences
         packed_input_ids = torch.cat(packed_input_ids, dim=0)
         packed_labels = torch.cat(packed_labels, dim=0)
-        packed_position_ids = torch.cat(packed_position_ids, dim=2)
+        # position_ids per sample are [num_mrope_axes, seq_len]; concat along the sequence axis.
+        # Each sample already restarts positions from 0, which — combined with the block-diagonal
+        # mask below — reproduces the varlen/packed attention semantics natively.
+        packed_position_ids = torch.cat(packed_position_ids, dim=-1).unsqueeze(1)  # [axes, 1, total_len]
 
-        # Only collect pixel_values and image_grid_thw from samples that were actually packed
-        # This prevents mismatch between image tokens in input_ids and image features
         all_pixel_values = [
             features[i]["pixel_values"] for i in packed_sample_indices if features[i]["pixel_values"] is not None
         ]
@@ -355,26 +396,19 @@ class PackedVLDataCollator:
             features[i]["image_grid_thw"] for i in packed_sample_indices if features[i]["image_grid_thw"] is not None
         ]
 
-        # 构建attention_mask = cumsum_seq_lens, 使其能够用于flash attention
-        # cu_seqlens only covers original sample lengths (MTP is handled separately)
-        cumsum_seq_lens = torch.cumsum(torch.tensor([0] + sample_lengths), dim=0, dtype=torch.int32)
-        attention_mask = cumsum_seq_lens
+        attention_mask = self._create_packed_causal_mask(sample_lengths, dtype=torch.float32)
 
-        # Prepare batch (add batch dimension)
         batch = {
             "input_ids": packed_input_ids.unsqueeze(0),  # [1, total_length]
-            "attention_mask": attention_mask,  # cumsum_seq_lens for flash attention (original only)
-            "position_ids": packed_position_ids,  # [1, 4, total_length]
+            "attention_mask": attention_mask,  # block-diagonal additive causal mask [1, 1, L, L]
+            "position_ids": packed_position_ids,  # [num_mrope_axes, 1, total_length]
             "labels": packed_labels.unsqueeze(0),  # [1, total_length]
         }
 
-        # Handle image inputs
         if all_pixel_values:
             batch["pixel_values"] = torch.cat(all_pixel_values, dim=0)
-
         if all_image_grid_thw:
             batch["image_grid_thw"] = torch.cat(all_image_grid_thw, dim=0)
-        # print('input_ids', batch['input_ids'].shape, 'image_mask', batch['image_mask'].shape)
         return batch
 
 
@@ -386,44 +420,39 @@ class VLDataCollator:
         self.max_length = max_length
 
     def __call__(self, features: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
-        # Separate different types of inputs
         input_ids = [f["input_ids"] for f in features]
         attention_mask = [f["attention_mask"] for f in features]
         labels = [f["labels"] for f in features]
-        pixel_values = [f["pixel_values"] for f in features if f["pixel_values"] is not None]
-        image_grid_thw = [f["image_grid_thw"] for f in features if f["image_grid_thw"] is not None]
-        [f["position_ids"] for f in features]
+        max_len = min(max(ids.shape[-1] for ids in input_ids), self.max_length)
+        pad_token_id = self.processor.tokenizer.pad_token_id
 
-        # Pad sequences
-        max_len = min(max(len(ids) for ids in input_ids), self.max_length)
-
-        padded_input_ids = []
-        padded_attention_mask = []
-        padded_labels = []
-
-        for ids, mask, label in zip(input_ids, attention_mask, labels):
-            padding_length = max_len - len(ids)
-            if padding_length > 0:
-                padded_input_ids.append(
-                    torch.cat([ids, torch.full((padding_length,), self.processor.tokenizer.pad_token_id)])
-                )
-                padded_attention_mask.append(torch.cat([mask, torch.zeros(padding_length, dtype=mask.dtype)]))
-                padded_labels.append(torch.cat([label, torch.full((padding_length,), -100)]))
-            else:
-                padded_input_ids.append(ids[:max_len])
-                padded_attention_mask.append(mask[:max_len])
-                padded_labels.append(label[:max_len])
+        def pad_sequence(tensor: torch.Tensor, value: int | bool) -> torch.Tensor:
+            tensor = tensor[..., :max_len]
+            padding_length = max_len - tensor.shape[-1]
+            if padding_length == 0:
+                return tensor
+            padding_shape = (*tensor.shape[:-1], padding_length)
+            padding = torch.full(padding_shape, value, dtype=tensor.dtype, device=tensor.device)
+            return torch.cat([tensor, padding], dim=-1)
 
         batch = {
-            "input_ids": torch.stack(padded_input_ids),
-            "attention_mask": torch.stack(padded_attention_mask),
-            "labels": torch.stack(padded_labels),
+            "input_ids": torch.stack([pad_sequence(ids, pad_token_id) for ids in input_ids]),
+            "attention_mask": torch.stack([pad_sequence(mask, False) for mask in attention_mask]),
+            "labels": torch.stack([pad_sequence(label, -100) for label in labels]),
         }
 
+        optional_token_fields = ("position_ids", "mm_token_type_ids")
+        for field in optional_token_fields:
+            values = [f.get(field) for f in features]
+            if all(value is not None for value in values):
+                batch[field] = torch.stack([pad_sequence(value, 0) for value in values])
+
+        pixel_values = [f["pixel_values"] for f in features if f.get("pixel_values") is not None]
+        image_grid_thw = [f["image_grid_thw"] for f in features if f.get("image_grid_thw") is not None]
         if pixel_values:
-            batch["pixel_values"] = torch.stack(pixel_values)
+            batch["pixel_values"] = torch.cat(pixel_values, dim=0)
         if image_grid_thw:
-            batch["image_grid_thw"] = torch.stack(image_grid_thw)
+            batch["image_grid_thw"] = torch.cat(image_grid_thw, dim=0)
 
         return batch
 

--- a/train/train_hunyuan.py
+++ b/train/train_hunyuan.py
@@ -42,7 +42,6 @@ from train.argument import (
     TrainingArguments,
 )
 from train.data_processor import PackedVLDataCollator, VLDataCollator, VLDataset
-from train.trainer import replace_hunyuanocr_attention_class
 
 transformers.logging.set_verbosity_info()
 
@@ -51,8 +50,9 @@ local_rank = None
 
 logging.basicConfig(level=logging.INFO, force=True)
 
+
 def rank0_print(*args):
-    if local_rank == 0:
+    if local_rank in (None, 0):
         print(*args)
 
 
@@ -87,19 +87,22 @@ def set_model(model_args, model):
             p.requires_grad = False
 
     if model_args.tune_mm_llm:
-        for n, p in model.model.named_parameters():
+        for _, p in model.model.named_parameters():
             p.requires_grad = True
-        model.lm_head.requires_grad = True
+        for p in model.lm_head.parameters():
+            p.requires_grad = True
     else:
-        for n, p in model.model.named_parameters():
+        for _, p in model.model.named_parameters():
             p.requires_grad = False
-        model.lm_head.requires_grad = False
+        for p in model.lm_head.parameters():
+            p.requires_grad = False
 
 
-def train(attn_implementation="flash_attention_2"):
+def train(attn_implementation=None):
     global local_rank
 
-
+    if attn_implementation is None:
+        attn_implementation = os.environ.get("HYOCR_ATTN_IMPLEMENTATION", "eager")
 
     parser = transformers.HfArgumentParser(
         (ModelArguments, DataArguments, TrainingArguments)
@@ -109,9 +112,8 @@ def train(attn_implementation="flash_attention_2"):
     
 
     local_rank = training_args.local_rank
-    # if not training_args.use_deepspeed:
-    #     torch.distributed.init_process_group(backend='nccl')
-    #     torch.cuda.set_device(torch.device(f'cuda:{local_rank}'))
+    if local_rank is None or local_rank < 0:
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
     os.makedirs(training_args.output_dir, exist_ok=True)
 
     training_args.lr_scheduler_kwargs = {'min_lr': 2e-6}
@@ -146,8 +148,9 @@ def train(attn_implementation="flash_attention_2"):
             trust_remote_code=True
         )
 
-    if data_args.data_flatten or data_args.data_packing:
-        replace_hunyuanocr_attention_class()
+    # Packed/flatten training uses the model's native packing support (block-diagonal
+    # causal mask + per-sample position_ids emitted by PackedVLDataCollator); no attention
+    # monkey-patching is required.
     model.config.use_cache = False
 
     if training_args.gradient_checkpointing:
@@ -179,7 +182,7 @@ def train(attn_implementation="flash_attention_2"):
     else:
         set_model(model_args, model)
 
-        if torch.distributed.get_rank() == 0:
+        if local_rank == 0:
             model.vit.print_trainable_parameters()
             model.model.print_trainable_parameters()
 
@@ -193,6 +196,7 @@ def train(attn_implementation="flash_attention_2"):
         processor=processor,
         max_length=data_args.packed_max_length,
         is_packed=data_args.data_flatten or data_args.data_packing,
+        model_config=model.config,
     )
     
     eval_dataset = None
@@ -233,4 +237,7 @@ def train(attn_implementation="flash_attention_2"):
 
 
 if __name__ == "__main__":
-    train(attn_implementation="flash_attention_2")
+    # attn_implementation defaults to eager (overridable via HYOCR_ATTN_IMPLEMENTATION).
+    # The packed path uses a block-diagonal 4D causal mask that eager/sdpa consume directly;
+    # flash_attention_2 expects varlen cu_seqlens instead, so do not hard-code it here.
+    train()

--- a/train/trainer.py
+++ b/train/trainer.py
@@ -1,204 +1,22 @@
-
 import torch
-from flash_attn.flash_attn_interface import flash_attn_varlen_func
 from transformers import Trainer
-from transformers.cache_utils import Cache
-from transformers.processing_utils import Unpack
-from transformers.utils import TransformersKwargs, logging
-from transformers.utils.deprecation import deprecate_kwarg
+from transformers.utils import logging
 
 logger = logging.get_logger(__name__)
 
-
-import transformers
 from transformers.models.hunyuan_vl.modeling_hunyuan_vl import (
     HunYuanVLModel,
     HunYuanVLVisionTransformer,
-    apply_rotary_pos_emb,
-    apply_rotary_pos_emb_xdrope,
 )
 
 
-def flash_attention_forward(
-    module: torch.nn.Module,
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
-    attention_mask: torch.Tensor | None,
-    dropout: float = 0.0,
-    scaling: float | None = None,
-    sliding_window: int | None = None,
-    softcap: float | None = None,
-    **kwargs,
-) -> tuple[torch.Tensor, None]:
-    if kwargs.get("output_attentions", False) or kwargs.get("head_mask") is not None:
-        logger.warning_once(
-            "`flash_attention_2` does not support `output_attentions=True` or `head_mask`."
-            " Please set your attention to `eager` if you want any of these features."
-        )
-    
-    # This is before the transpose
-    query.shape[2]
-
-    if any(dim == 0 for dim in query.shape):
-        raise ValueError(
-            "Tensor query has shape  with a zero dimension.\n"
-            "FlashAttention does not support inputs with dim=0.\n"
-            "Please check your input shapes or use SDPA instead."
-        )
-    # FA2 uses non-transposed inputs
-    # batch, head, seq_len, dim
-    query = query.transpose(1, 2)
-    key = key.transpose(1, 2)
-    value = value.transpose(1, 2)
-    # batch, seqlen, head, dim
-
-    # In PEFT, usually we cast the layer norms in float32 for training stability reasons
-    # therefore the input hidden states gets silently casted in float32. Hence, we need
-    # cast them back in the correct dtype just to be sure everything works as expected.
-    # This might slowdown training & inference so it is recommended to not cast the LayerNorms
-    # in fp32. (usually our RMSNorm modules handle it correctly)
-    if query.dtype == torch.float32:
-        if torch.is_autocast_enabled():
-            torch.get_autocast_gpu_dtype()
-        # Handle the case where the model is quantized
-        elif hasattr(module.config, "_pre_quantization_dtype"):
-            pass
-        else:
-            # Access .weight.dtype to trigger lazy load / dtype resolution.
-            # Kept as an expression-statement to mirror upstream HuggingFace
-            # FlashAttention integrations (LlamaFlashAttention2 et al.).
-            next(layer for layer in module.modules() if isinstance(layer, torch.nn.Linear)).weight.dtype  # noqa: B018
-
-    query = query.squeeze(0)
-    key = key.squeeze(0)
-    value = value.squeeze(0)
-    cu_seqlens = attention_mask
-
-    with torch.no_grad():
-        max_seqlen = max(
-            [
-                cu_seqlens[idx + 1] - cu_seqlens[idx]
-                for idx in range(cu_seqlens.size(0) - 1)
-            ]
-        ).item()
-
-    attn_output = flash_attn_varlen_func(
-        query,
-        key,
-        value,
-        cu_seqlens_q=cu_seqlens,
-        cu_seqlens_k=cu_seqlens,
-        max_seqlen_q=max_seqlen,
-        max_seqlen_k=max_seqlen,
-        causal=True,
-    )
-
-    attn_output = attn_output.unsqueeze(0)
-
-    return attn_output, None
-
-
-@deprecate_kwarg("past_key_value", new_name="past_key_values", version="4.58")
-def hunyuanvl_forward(
-    self,
-    hidden_states: torch.Tensor,
-    position_embeddings: tuple[torch.Tensor, torch.Tensor],
-    position_ids: torch.LongTensor | None = None,
-    attention_mask: torch.Tensor | None = None,
-    past_key_values: Cache | None = None,
-    cache_position: torch.LongTensor | None = None,
-    **kwargs: Unpack[TransformersKwargs],
-) -> tuple[torch.Tensor, torch.Tensor]:
-    input_shape = hidden_states.shape[:-1]
-    hidden_shape = (*input_shape, -1, self.head_dim)
-
-    query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
-    key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
-    value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
-
-    kv_seq_len = key_states.shape[-2]
-    origin_kv_seq_len = key_states.shape[-2]
-    if past_key_values is not None:
-        kv_seq_len += past_key_values.get_seq_length(self.layer_idx)
-
-    if self.xdrope_section is not None and position_ids is not None and position_ids.dim() >= 3:
-        cos, sin = self.rotary_emb(
-            value_states,
-            position_ids=position_ids,
-            xdrope_section=self.xdrope_section,
-        )
-        output_size = (
-            query_states.size(0),
-            query_states.size(1),
-            query_states.size(2),
-            key_states.size(2),
-        )
-        query_states, key_states = apply_rotary_pos_emb_xdrope(
-            query_states, key_states, cos, sin, position_ids, self.xdrope_section, output_size
-        )
-    else:
-        if position_ids is not None:
-            kv_seq_len = max(kv_seq_len, int(position_ids.max().item()) + 1)
-        cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-        position_ids = torch.ones(
-            position_ids.shape[0], 1, dtype=torch.long, device=position_ids.device
-        ) * past_key_values.get_seq_length(self.layer_idx)
-        cos, sin = cos[-origin_kv_seq_len:, :], sin[-origin_kv_seq_len:, :]
-        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
-
-    query_states = self.query_layernorm(query_states)
-    key_states = self.key_layernorm(key_states)
-
-    if past_key_values is not None:
-        # sin and cos are specific to RoPE models; cache_position needed for the static cache
-        cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
-        key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
-
-    
-    attn_output, attn_weights = flash_attention_forward(
-        self,
-        query_states,
-        key_states,
-        value_states,
-        attention_mask,
-        dropout=0.0 if not self.training else self.attention_dropout,
-        scaling=self.scaling,
-        **kwargs,
-    )
-
-    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
-    attn_output = self.o_proj(attn_output)
-    return attn_output, attn_weights
-
-def return_mask(
-    config,
-    input_embeds,
-    attention_mask,
-    cache_position,
-    past_key_values,
-    position_ids,
-    **kwargs
-):
-    return attention_mask
-
-def replace_hunyuanocr_attention_class():
-    """Replace HunYuanVL attention forward and create_causal_mask for flash_attention_2 support."""
-    # Replace the forward method of HunYuanVLAttention
-    transformers.models.hunyuan_vl.modeling_hunyuan_vl.HunYuanVLAttention.forward = (
-        hunyuanvl_forward
-    )
-    
-    # Replace create_causal_mask in the modeling module
-    # This needs to be done at the module level where it's imported
-    # import transformers.masking_utils
-    # transformers.masking_utils.create_causal_mask = return_mask
-    
-    # Also replace in the modeling_hunyuan_vl module's namespace
-    transformers.models.hunyuan_vl.modeling_hunyuan_vl.create_causal_mask = return_mask
-    
-    print("Successfully replaced HunYuanVLAttention.forward and create_causal_mask for flash_attention_2")
-
+# NOTE: HunyuanOCR packed training uses the model's NATIVE packing support.
+# The old flash_attention_2 monkey-patch (hunyuanvl_forward / apply_rotary_pos_emb_xdrope /
+# replace_hunyuanocr_attention_class) targeted a `HunYuanVLAttention` class that no longer
+# exists in transformers>=5.15 (superseded by `HunYuanVLDenseV1Attention`, which already
+# applies the correct multimodal RoPE). Packing is instead achieved by feeding per-sample
+# restarted 3D position_ids plus a block-diagonal causal mask (see PackedVLDataCollator),
+# which the native forward consumes directly. No attention patching is required.
 
 
 def print_trainable_parameters_visual(self) -> None:


### PR DESCRIPTION
启动与可导入性:
- sft_base.sh 用 Bash 数组传参 (原 "${args}" 会被合并成单个 argv), 加 set -o pipefail, 并把 packed/max_steps/dataloader workers 等做成可覆盖的环境变量
- trainer.py 移除与当前 API 不兼容的死代码 (hunyuanvl_forward / apply_rotary_pos_emb_xdrope / replace_hunyuanocr_attention_class): 目标类 HunYuanVLAttention 已被 HunYuanVLDenseV1Attention 取代且自带正确的 multimodal RoPE,旧 XD-RoPE monkey-patch 不再需要
- train_hunyuan.py 用安全的 local_rank 替代未初始化时的 torch.distributed.get_rank(), 正确对 lm_head.parameters() 设置 requires_grad, attn默认 eager (可用 HYOCR_ATTN_IMPLEMENTATION 覆盖)

数据管道 (符合当前 HunYuanVL forward 协议):
- 标准路径去除 processor 多余 batch 维, 视觉输入用 cat 保持 flat,屏蔽 image token 的 label, 透传 mm_token_type_ids
- packed 路径改用模型原生打包: 每样本从 0 重启的 3D position_ids (复用模型自身 get_rope_index 经config-only shim 计算) + block-diagonal 4D 因果 mask, 无需attention patch / flash_attn / cu_seqlens
- pipeline_count_and_pack.py 增加输入 schema 适配 (兼容 conv+img_path_* 与 image_path+conversations), 文档更新为实际的每行一个 list 的打包输出

依赖: requirements 补lmdb / binpacking

验证: 用config 构建的 tiny HunYuanVLForConditionalGeneration + 真实 dataset/collator完成 标准与 packed 两条路径的 forward/backward/optimizer/save 全链路, 并验证 packed 的跨样本 block-diagonal 隔离 (改动一个样本的 token 不影响其他样本 logits)